### PR TITLE
fix the indicator order

### DIFF
--- a/src/applet-main.c
+++ b/src/applet-main.c
@@ -32,10 +32,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 static gchar * indicator_order[] = {
 	"libapplication.so",
-	"libsoundmenu.so",
 	"libmessaging.so",
+	"libsoundmenu.so",
 	"libdatetime.so",
-	"libme.so",
+	"libsession.so",
 	NULL
 };
 


### PR DESCRIPTION
the indicator order for the latest version of Unity can be seen here: http://bazaar.launchpad.net/~unity-team/unity/trunk/view/head:/services/panel-service.c#L111
