### PR TITLE
Change url project's website

### DIFF
--- a/README
+++ b/README
@@ -7,4 +7,4 @@ The indicator applet exposes Ayatana Indicators in the MATE Panel. Ayatana Indic
 
 MATE Indicator Applet is a fork of Indicator Applet for GNOME (https://launchpad.net/indicator-applet).
 
-http://www.mate-desktop.org/
+https://mate-desktop.org/

--- a/src/applet-main.c
+++ b/src/applet-main.c
@@ -790,7 +790,7 @@ about_cb (GtkAction *action G_GNUC_UNUSED,
 		"translator-credits", _("translator-credits"),
 		"logo-icon-name", "mate-indicator-applet",
 		"icon-name", "mate-indicator-applet",
-		"website", "http://www.mate-desktop.org",
+		"website", "https://mate-desktop.org",
 		"website-label", _("MATE Website"),
 		NULL
 	);


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.