### PR TITLE
Add help compilation to Ubuntu's users

### DIFF
--- a/README
+++ b/README
@@ -7,4 +7,9 @@ The indicator applet exposes Ayatana Indicators in the MATE Panel. Ayatana Indic
 
 MATE Indicator Applet is a fork of Indicator Applet for GNOME (https://launchpad.net/indicator-applet).
 
+Only Ubuntu users MUST use:
+./autogen.sh --with-ayatana-indicators for Ayatana Indicators
+or
+./autogen.sh --with-ubuntu-indicators for Ubuntu indicators
+
 https://mate-desktop.org/

--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ elif test "x$have_ubuntuindicator" != "xyes" &&
 
 else
 
-    AC_MSG_ERROR([Either Ayatana Indicators or Ubuntu Indicators are required to build mate-indicator-applet.])
+    AC_MSG_ERROR([Either Ayatana Indicators (--with-ayatana-indicators) or Ubuntu Indicators (--with-ubuntu-indicators) are required to build mate-indicator-applet.])
 
 fi
 


### PR DESCRIPTION
On Ubuntu 19.04, without this PR, i have got this message:
> Either Ayatana Indicators or Ubuntu Indicators are required to build mate-indicator-applet.

with no more help (including README file).

Regards