### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_CONFIG_MACRO_DIR([m4])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 ###########################
-# Dependencies 
+# Dependencies
 ###########################
 
 GTK_REQUIRED_VERSION=3.22.0
@@ -258,7 +258,7 @@ else
   REAL_PREFIX=$prefix
 fi
 
-# Have to go $sysconfdir->$prefix/etc->/usr/local/etc   
+# Have to go $sysconfdir->$prefix/etc->/usr/local/etc
 # if you actually know how to code shell then fix this :-)
 SYSCONFDIR_TMP="$sysconfdir"
 old_prefix=$prefix

--- a/src/eggaccelerators.h
+++ b/src/eggaccelerators.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA 
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
  */
 
 #ifndef __EGG_ACCELERATORS_H__
@@ -34,7 +34,7 @@ typedef enum
   EGG_VIRTUAL_CONTROL_MASK  = 1 << 2,
 
   EGG_VIRTUAL_ALT_MASK      = 1 << 3, /* fixed as Mod1 */
-  
+
   EGG_VIRTUAL_MOD2_MASK	    = 1 << 4,
   EGG_VIRTUAL_MOD3_MASK	    = 1 << 5,
   EGG_VIRTUAL_MOD4_MASK	    = 1 << 6,
@@ -48,11 +48,11 @@ typedef enum
   GDK_BUTTON5_MASK  = 1 << 12,
   /* 13, 14 are used by Xkb for the keyboard group */
 #endif
-  
+
   EGG_VIRTUAL_META_MASK = 1 << 24,
   EGG_VIRTUAL_SUPER_MASK = 1 << 25,
   EGG_VIRTUAL_HYPER_MASK = 1 << 26,
-  EGG_VIRTUAL_MODE_SWITCH_MASK = 1 << 27, 
+  EGG_VIRTUAL_MODE_SWITCH_MASK = 1 << 27,
   EGG_VIRTUAL_NUM_LOCK_MASK = 1 << 28,
   EGG_VIRTUAL_SCROLL_LOCK_MASK = 1 << 29,
 
@@ -61,7 +61,7 @@ typedef enum
 
   /*     28-31 24-27 20-23 16-19 12-15 8-11 4-7 0-3
    *       7     f     0     0     0    0    f   f
-   */  
+   */
   EGG_VIRTUAL_MODIFIER_MASK = 0x7f0000ff
 
 } EggVirtualModifierType;

--- a/src/tomboykeybinder.h
+++ b/src/tomboykeybinder.h
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA 
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
  */
 #ifndef __TOMBOY_KEY_BINDER_H__
 #define __TOMBOY_KEY_BINDER_H__


### PR DESCRIPTION
`find . -regextype posix-extended -regex '.*\.(c|h|ac)' -exec sed --in-place 's/[[:space:]]\+$//' {} \+`

like rbuj do on [https://github.com/mate-desktop/mate-control-center/pull/463](https://github.com/mate-desktop/mate-control-center/pull/463).