### PR TITLE
use MATE_COMPILE_WARNINGS from mate-common

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -4,6 +4,7 @@
 requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/mate-indicator-applet
+    - autoconf-archive
     - clang
     - gcc
     - git
@@ -17,6 +18,7 @@ requires:
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
     # Useful URL: https://salsa.debian.org/debian-mate-team/mate-indicator-applet
+    - autoconf-archive
     - autopoint
     - clang
     - clang-tools
@@ -34,6 +36,7 @@ requires:
 
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/mate-indicator-applet.git
+    - autoconf-archive
     - clang
     - clang-analyzer
     - cppcheck-htmlreport
@@ -47,6 +50,7 @@ requires:
     - redhat-rpm-config
 
   ubuntu:
+    - autoconf-archive
     - autopoint
     - clang
     - clang-tools

--- a/.build.yml
+++ b/.build.yml
@@ -66,7 +66,6 @@ requires:
     - mate-common
 
 variables:
-  - CFLAGS="-Wall -Werror=format-security -Wredundant-decls"
   - 'CHECKERS="
     -enable-checker deadcode.DeadStores
     -enable-checker alpha.deadcode.UnreachableCode
@@ -99,7 +98,7 @@ before_scripts:
 
 build_scripts:
   - ./autogen.sh
-  - scan-build $CHECKERS ./configure
+  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT
   - else

--- a/.build.yml
+++ b/.build.yml
@@ -84,6 +84,19 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - cd ${START_DIR}
+  - '[ -f mate-common-1.24.1.tar.xz ] || curl -Ls -o mate-common-1.24.1.tar.xz https://github.com/mate-desktop/mate-common/releases/download/v1.24.1/mate-common-1.24.1.tar.xz'
+  - tar xf mate-common-1.24.1.tar.xz
+  - cd mate-common-1.24.1
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
+  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
+  - else
+  -     ./configure --prefix=/usr
+  - fi
+  - make
+  - make install
+
 build_scripts:
   - ./autogen.sh
   - scan-build $CHECKERS ./configure

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,8 @@ AC_CONFIG_MACRO_DIR([m4])
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
+MATE_COMPILE_WARNINGS
+
 ###########################
 # Dependencies
 ###########################
@@ -308,6 +310,7 @@ AC_MSG_NOTICE([
 Indicator Applet Configuration:
 
 	Prefix:                         $prefix
+	Warning cflags:                 ${WARN_CFLAGS}
 	Indicator implementation:       $indicator_implementation
 	Indicator NG support:           $have_indicator_ng
 	Indicator Directory:            $INDICATORDIR

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,8 @@ mate_indicator_applet_CFLAGS = \
 	-DINDICATOR_APPLET \
 	-I$(srcdir)/.. \
 	$(APPLET_CFLAGS) \
-	$(INDICATOR_CFLAGS)
+	$(INDICATOR_CFLAGS) \
+	$(WARN_CFLAGS)
 
 mate_indicator_applet_SOURCES = \
 	applet-main.c \
@@ -47,7 +48,8 @@ mate_indicator_applet_appmenu_CFLAGS = \
 	-DINDICATOR_APPLET_APPMENU \
 	-I$(srcdir)/.. \
 	$(APPLET_CFLAGS) \
-	$(INDICATOR_CFLAGS)
+	$(INDICATOR_CFLAGS) \
+	$(WARN_CFLAGS)
 
 mate_indicator_applet_appmenu_SOURCES = \
 	applet-main.c \
@@ -69,7 +71,8 @@ mate_indicator_applet_complete_CFLAGS = \
 	-DINDICATOR_APPLET_COMPLETE \
 	-I$(srcdir)/.. \
 	$(APPLET_CFLAGS) \
-	$(INDICATOR_CFLAGS)
+	$(INDICATOR_CFLAGS) \
+	$(WARN_CFLAGS)
 
 mate_indicator_applet_complete_SOURCES =	\
 	applet-main.c \


### PR DESCRIPTION
default WARN_CFLAGS level is [yes]

Test: `./configure --enable-compile-warnings=[no/minimum/yes/maximum/error]`