### PR TITLE
applet-main: Replace GtkStock icon

### DIFF
--- a/src/applet-main.c
+++ b/src/applet-main.c
@@ -963,7 +963,7 @@ applet_fill_cb (MatePanelApplet * applet, const gchar * iid G_GNUC_UNUSED,
 #endif
 
 	static const GtkActionEntry menu_actions[] = {
-		{"About", GTK_STOCK_ABOUT, N_("_About"), NULL, NULL, G_CALLBACK(about_cb)}
+		{"About", "help-about", N_("_About"), NULL, NULL, G_CALLBACK(about_cb)}
 	};
 	static const gchar *menu_xml = "<menuitem name=\"About\" action=\"About\"/>";
 


### PR DESCRIPTION
> GTK_STOCK_ABOUT has been deprecated since version 3.10 and should not be used in newly-written code.
> Use named icon "help-about" or the label "_About".

https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html#GTK-STOCK-ABOUT:CAPS