### PR TITLE
Fix GList memory leak in entry_resized

### DIFF
--- a/src/applet-main.c
+++ b/src/applet-main.c
@@ -380,6 +380,8 @@ entry_resized (GtkWidget *applet, guint newsize, gpointer data)
 		}
 	}
 
+	g_list_free(entries);
+
 	return FALSE;
 }
 


### PR DESCRIPTION
## Summary

`entry_resized()` calls `indicator_object_get_entries()` which returns a newly-allocated `GList`, but never frees it. This leaks GList nodes on every panel `change-size` signal.

The other callers of `indicator_object_get_entries()` in this file correctly free the returned list:
- `menu_show` (line 589): `g_list_free(entries)`
- `load_indicator` (line 657): `g_list_free(entries)`

## Evidence

The bug is visible by inspection. Here are all three call sites for comparison:

```c
// entry_resized (LEAKS - missing g_list_free):
GList * entries = indicator_object_get_entries(io);
for (entry = entries; ...) { ... }
return FALSE;  // no g_list_free!

// menu_show (correct):
GList * entries = indicator_object_get_entries(io);
for (iterator = entries; ...) { ... }
g_list_free(entries);  // freed

// load_indicator (correct):
GList * entries = indicator_object_get_entries(io);
for (entry = entries; ...) { ... }
g_list_free(entries);  // freed
```

## Context

This was found while investigating why `mate-indicator-applet-complete` accumulates ~1.4 GB of heap memory over 7 days on Ubuntu 24.04. This specific leak is a minor contributor (GList nodes are small), but is a clear bug that should be fixed. The major memory leak sources are in `ayatana-indicator-application` (being reported separately).

## Fix

Add the missing `g_list_free(entries)` call after the loop in `entry_resized()`.